### PR TITLE
feat(formbuilder): make confirm dialog thenable

### DIFF
--- a/packages/boplus-vue-vanilla/src/components/ArrayLayoutRenderer.vue
+++ b/packages/boplus-vue-vanilla/src/components/ArrayLayoutRenderer.vue
@@ -148,9 +148,12 @@ const addButtonClick = () => {
 };
 
 const onDelete = (index: number) => {
-  if (confirm('Delete Element: ' + input.childLabelForIndex(index))) {
-    input?.removeItems(input.control.value.path, [index])();
-  }
+  Promise.resolve(window.confirm('Delete Element: ' + input.childLabelForIndex(index)))
+      .then((confirmed: boolean) => {
+        if (confirmed) {
+          input?.removeItems(input.control.value.path, [index])();
+        }
+      });
 }
 
 </script>

--- a/src/components/tools/array.component.vue
+++ b/src/components/tools/array.component.vue
@@ -172,9 +172,12 @@ const onDeleteByIndex = (e) => {
   emitter.emit('formBuilderUpdated')
 };
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 </script>

--- a/src/components/tools/categorization.vue
+++ b/src/components/tools/categorization.vue
@@ -229,8 +229,11 @@ const onDeleteByIndex = (e) => {
 };
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 </script>

--- a/src/components/tools/combinator.component.vue
+++ b/src/components/tools/combinator.component.vue
@@ -152,9 +152,12 @@ const onDeleteByIndex = (e) => {
   emitter.emit('formBuilderUpdated')
 };
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 </script>

--- a/src/components/tools/const.vue
+++ b/src/components/tools/const.vue
@@ -50,9 +50,12 @@ const emit = defineEmits(['deleteByIndex']);
 defineExpose({tool: props.tool})
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 </script>

--- a/src/components/tools/flexArea.vue
+++ b/src/components/tools/flexArea.vue
@@ -198,8 +198,11 @@ const onDropAreaChange = (e) => {
 };
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 </script>

--- a/src/components/tools/formInputByType.vue
+++ b/src/components/tools/formInputByType.vue
@@ -94,9 +94,12 @@ const uischema = props.tool.uischema;
 const inputType = computed(() => guessInputType(props.tool.schema, props.tool.uischema));
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 

--- a/src/components/tools/label.vue
+++ b/src/components/tools/label.vue
@@ -42,9 +42,12 @@ const emit = defineEmits(['deleteByIndex']);
 defineExpose({tool: props.tool})
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 </script>

--- a/src/components/tools/object.component.vue
+++ b/src/components/tools/object.component.vue
@@ -158,9 +158,12 @@ const onDeleteByIndex = (e) => {
   emitter.emit('formBuilderUpdated')
 };
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 </script>

--- a/src/components/tools/reference.vue
+++ b/src/components/tools/reference.vue
@@ -48,8 +48,11 @@ const emit = defineEmits(['deleteByIndex']);
 defineExpose({tool: props.tool})
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 </script>

--- a/src/components/tools/unknown.vue
+++ b/src/components/tools/unknown.vue
@@ -40,9 +40,12 @@ const emit = defineEmits(['deleteByIndex']);
 defineExpose({ tool:props.tool })
 
 const onDelete = () => {
-  if (confirm("Wirklich löschen?")) {
-    emit('deleteByIndex', {index: props.index});
-  }
+  Promise.resolve(window.confirm("Wirklich löschen?"))
+      .then((confirmed) => {
+        if(confirmed) {
+          emit("deleteByIndex", { index: props.index });
+        }
+      });
 };
 
 </script>


### PR DESCRIPTION
I wrapped the confirm call in a promise because this will help me override the window.confirm function with an asynchronous function for the vs code plugin.
I also tested it in a browser (firefox) and it didn't cause any problems.